### PR TITLE
Improve mpv states

### DIFF
--- a/examples/mpv_example.tcl
+++ b/examples/mpv_example.tcl
@@ -121,6 +121,7 @@ proc main_loop {} {
 
 		26 {
 			puts "time: $::loopcnt seconds"
+			puts "eof reason: expected: {external action}{success}, actual value [::tclmpv::eofinfo]"
 			puts "tclmpv state: expected: Idle, actual value: [::tclmpv::state] "
 		}
 
@@ -177,7 +178,8 @@ proc main_loop {} {
 		39 {
 			puts "time: $::loopcnt seconds"
 			puts "load a file and start to play"
-			::tclmpv::loadfile winchester_cathedral_30s.mp3
+			# load 10 seconds from the end
+			::tclmpv::loadfile soul_bossa_nova_30s.mp3 start=-10
 		}
 
 		41 {
@@ -185,13 +187,31 @@ proc main_loop {} {
 			# by querying the duration and the actual time
 			puts "time: $::loopcnt seconds"
 			puts "tclmpv duration: expected: 30, actual value: [::tclmpv::duration] "
-			puts "tclmpv time: expected: 2, actual value: [::tclmpv::gettime] "
+			puts "tclmpv time: expected: 22, actual value: [::tclmpv::gettime] "
 			}
 
-		43 {
+		51 {
+			# Check that eofinfo returns the correct information
 			puts "time: $::loopcnt seconds"
-			puts "stop the playback"
-			::tclmpv::stop
+			puts "eof reason: expected: {end of file reached}{success}, actual value [::tclmpv::eofinfo]"
+			puts "tclmpv state: expected: Idle, actual value: [::tclmpv::state] "
+		}
+
+		52 {
+			# loadfile does not check on errors like non-existing files or streams
+			# mpv does not return an error executing the loadfile command
+			# since eof is detected this should give us the information
+			puts "time: $::loopcnt seconds"
+			puts "load non existing file"
+			::tclmpv::loadfile foo.mp3
+			puts "eof reason: expected: {end of file reached}{success}, actual value [::tclmpv::eofinfo]"
+		}
+
+		54 {
+			# Give mpv some time to try and find the file and send the events
+			puts "time: $::loopcnt seconds"
+			puts "eof reason: expected: {error playback abort} {loading failed}, actual value [::tclmpv::eofinfo]"
+			puts "tclmpv state: expected: Idle, actual value: [::tclmpv::state] "
 		}
 
 		default {
@@ -201,7 +221,7 @@ proc main_loop {} {
 
 	}
 	incr ::loopcnt
-	if { $::loopcnt > 45 } { set ::forever 1}
+	if { $::loopcnt > 55 } { set ::forever 1}
 	after 1000 main_loop
 }
 

--- a/examples/mpv_example.tcl
+++ b/examples/mpv_example.tcl
@@ -52,14 +52,13 @@ proc main_loop {} {
 			puts "time: $::loopcnt seconds"
 			puts "initialize the mpv player"
 			::tclmpv::init
-			puts "after 100 ms, ask for the player status"
-			after 100
-			puts "tclmpv state: expected: Idle, actual value: [::tclmpv::state]"
+			puts "tclmpv state: expected: None, actual value: [::tclmpv::state]"
 			puts "mpv library version: [::tclmpv::version]"
 		}
 
 		2 {
 			puts "time: $::loopcnt seconds"
+			puts "tclmpv state: expected: Idle, actual value: [::tclmpv::state]"
 			puts "load a file and start to play"
 			::tclmpv::loadfile soul_bossa_nova_30s.mp3
 		}
@@ -68,6 +67,7 @@ proc main_loop {} {
 			puts "time: $::loopcnt seconds"
 			puts "tclmpv state: expected: Playing, actual value: [::tclmpv::state] "
 			puts "tclmpv duration: expected: 30, actual value: [::tclmpv::duration] "
+			puts "tclmpv time: expected: > 0, actual value: [::tclmpv::gettime] "
 		}
 
 		8 {

--- a/generic/tclmpv.h
+++ b/generic/tclmpv.h
@@ -39,6 +39,15 @@ static const playStateMap_t playStateMap[] = {
 };
 #define playStateMapMax (sizeof(playStateMap)/sizeof(playStateMap_t))
 
+static const char *const efr_table[] = {
+// Table copied and adapted from mpv/player/client.c
+	[MPV_END_FILE_REASON_EOF] = "end of file reached",
+    [MPV_END_FILE_REASON_STOP] = "stop request",
+    [MPV_END_FILE_REASON_QUIT]= "quit request",
+    [MPV_END_FILE_REASON_ERROR]= "error playback abort",
+    [MPV_END_FILE_REASON_REDIRECT] = "file redirect",
+};
+
 typedef struct {
   mpv_event_id          state;
   const char *          name;
@@ -64,29 +73,30 @@ static const stateMap_t stateMap[] = {
 
 #define stateMapIdxMax 40 /* mpv currently has 24 states coded */
 typedef struct {
-  Tcl_Interp            *interp;
-  mpv_handle            *inst;
-  char                  version [40];
-  //mpv_event_id          state;
-  playstate				state;	
-  int                   argc;
-  const char            **argv;
-  const char            *device;
-  double                duration;
-  double                tm;
-  int                   paused;
-  int                   hasEvent;       /* flag to process mpv event */
-  Tcl_TimerToken        timerToken;
-  Tcl_TimerToken        tickToken;
-  int                   stateMapIdx [stateMapIdxMax];
-  FILE                  *debugfh;
+	 Tcl_Interp					*interp;
+	 mpv_handle					*inst;
+	 char						version [40];
+	 playstate					state;	
+	 int						argc;
+	 const char					**argv;
+	 const char					*device;
+	 double						duration;
+	 double						tm;
+	 int						paused;
+	 int						hasEvent;       /* flag to process mpv event */
+	 Tcl_TimerToken				timerToken;
+	 int						stateMapIdx [stateMapIdxMax];
+	 struct mpv_event_end_file	end_file;
+	 FILE		                *debugfh;
 } mpvData_t;
 
 const char * mpvStateToStr (mpv_event_id state);
 const char * stateToStr (playstate state);
+const char *mpv_efr_string(mpv_end_file_reason reason);
 void mpvCallbackHandler (void *cd);
 void mpvEventHandler (ClientData cd);
 int mpvDurationCmd (ClientData cd, Tcl_Interp* interp, int objc, Tcl_Obj * const objv[]);
+int mpvEofInfoCmd (ClientData cd, Tcl_Interp* interp, int objc, Tcl_Obj * const objv[]);
 int mpvGetTimeCmd ( ClientData cd, Tcl_Interp* interp, int objc, Tcl_Obj * const objv[]);
 int mpvIsPlayCmd ( ClientData cd, Tcl_Interp* interp, int objc, Tcl_Obj * const objv[]);
 int mpvMediaCmd ( ClientData cd, Tcl_Interp* interp, int objc, Tcl_Obj * const objv[]);
@@ -112,6 +122,7 @@ static const EnsembleData mpvCmdMap[] = {
   { "audiodevset",  mpvAudioDevSetCmd },
   { "close",        mpvReleaseCmd },
   { "duration",     mpvDurationCmd },
+  { "eofinfo",      mpvEofInfoCmd },
   { "gettime",      mpvGetTimeCmd },
   { "init",         mpvInitCmd },
   { "haveaudiodevlist", mpvHaveAudioDevListCmd },


### PR DESCRIPTION
Improved handling of Idle state within the extension. The generation of the Idle event by libmpv is depreciated. Instead the extension now observes the idle-active property change.
Added ::tclmpv::eofinfo to retrieve the information about the latest EOF event.